### PR TITLE
Changes "Open" to use file input and FileReader, fixes #2

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,15 @@
 		<nav class="light-blue lighten-1" role="navigation" id="header">
 			<div class="nav-wrapper container">
 				<div class="brand-logo white-text"><a href="index.html">DiscordBlocks</a></div>
+				<input onchange="loadCode(event)" hidden type="file" id="load-code" accept=".xml">
 				<ul class="right hide-on-med-and-down">
-					<li><a href="#" onclick="loadCode()">Open</a></li>
+					<li><label for="load-code"><a>Open</a></li></label></li>
 					<li><a href="#" onclick="saveCode()">Save</a></li>
 					<li><a href="#" onclick="getCode()">Export</a></li>
 					<li><a href="#" onclick="runCode()">Execute</a></li>
 				</ul>
 				<ul id="nav-mobile" class="side-nav">
-					<li><a href="#" onclick="loadCode()">Open</a></li>
+					<li><label for="load-code"><a>Open</a></li></label></li>
 					<li><a href="#" onclick="saveCode()">Save</a></li>
 					<li><a href="#" onclick="getCode()">Export</a></li>
 					<li><a href="#" onclick="runCode()">Execute</a></li>

--- a/js/discordblocks/index.js
+++ b/js/discordblocks/index.js
@@ -31,11 +31,16 @@ function runCode() {
 	w.js = Blockly.JavaScript.workspaceToCode(workspace);
 }
 
-function loadCode() {
-	const xml_text = prompt('Insert your XML saved extract');
-	if (!xml_text) return;
-	const xml = Blockly.Xml.textToDom(xml_text);
-	Blockly.Xml.domToWorkspace(xml, workspace);
+function loadCode(evt) {
+	const [file] = evt.target.files;
+	const reader = new FileReader();
+	reader.onload = (e) => {
+		const xml_text = e.target.result;
+		if (!xml_text) return;
+		const xml = Blockly.Xml.textToDom(xml_text);
+		Blockly.Xml.domToWorkspace(xml, workspace);
+	};
+	reader.readAsText(file);
 }
 
 window.addEventListener('beforeunload', (e) => {


### PR DESCRIPTION
I added a hidden `<input type="file">` element to the page. "Open" now links to the input rather than triggering the prompt, and once a file has been selected it will be loaded and the XML text will be parsed using the existing code. 